### PR TITLE
Modificato l'ordine con cui i documenti appaiono nel sito

### DIFF
--- a/.github/site-src/update_index.py
+++ b/.github/site-src/update_index.py
@@ -30,6 +30,18 @@ def build_html_tree(base_path, relative_path=""):
     # 1. Stampa SOLO i file .pdf
     valid_files = [f for f in files if f.endswith('.pdf')]
     if valid_files:
+        def get_sort_key(filename):
+            # Cerca una data nel nome del file (es. 2026-03-16 o 2026_03_16)
+            date_match = re.search(r'(\d{4})[-_](\d{2})[-_](\d{2})', filename)
+            if date_match:
+                # Restituisce la data come stringa YYYYMMDD per l'ordinamento
+                return (date_match.group(1) + date_match.group(2) + date_match.group(3), filename)
+            # Fallback: data di modifica del file e nome
+            return (str(os.path.getmtime(os.path.join(current_dir, filename))), filename)
+
+        # Ordina i file in ordine decrescente (più recenti in alto)
+        valid_files.sort(key=get_sort_key, reverse=True)
+        
         html_output += '    <div class="doc">\n'
         for f in valid_files:
             if relative_path:


### PR DESCRIPTION
I file PDF sono ora ordinati in base alla data estratta dai nomi dei file (se presente), oppure in base alla data di ultima modifica come soluzione di ripiego (fallback), garantendo che i file più recenti appaiano per primi.

Closes #34 